### PR TITLE
Add Label Capacity Feature and Size Preservation in Diff Mode

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -302,6 +302,18 @@ class Rollup {
     }
   }
 
+  // Create entries for all children which exist in "other" but not in this.
+  void AddEntriesFrom(const Rollup& other) {
+    for (const auto& other_child : other.children_) {
+      auto& child = children_[other_child.first];
+      if (child.get() == NULL) {
+        child.reset(new Rollup());
+      }
+      child->AddEntriesFrom(*other_child.second);
+    }
+  }
+
+
   int64_t file_total() const { return file_total_; }
   int64_t filtered_file_total() const { return filtered_file_total_; }
 
@@ -1865,7 +1877,7 @@ void Bloaty::ScanAndRollup(const Options& options, RollupOutput* output) {
       base_filenames.push_back(file_info.filename_);
     }
     ScanAndRollupFiles(base_filenames, &build_ids, &base);
-    rollup.Subtract(base);
+    rollup.AddEntriesFrom(base);
     rollup.CreateDiffModeRollupOutput(&base, options, output);
   } else {
     rollup.CreateRollupOutput(options, output);

--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -878,8 +878,6 @@ void RollupOutput::PrintToCSV(std::ostream* out, bool tabs) const {
   std::vector<std::string> names(source_names_);
   names.push_back("vmsize");
   names.push_back("filesize");
-  names.push_back("vmcapacity");	
-  names.push_back("filecapacity");	
   names.push_back("original_vmsize");	
   names.push_back("original_filesize");	
   names.push_back("current_vmsize");	

--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -274,10 +274,10 @@ class Rollup {
   void CreateDiffModeRollupOutput(Rollup* base, const Options& options,
                                   RollupOutput* output) const {
     RollupRow* row = &output->toplevel_row_;
-    row->vmsize = vm_total_;
-    row->filesize = file_total_;
-    row->filtered_vmsize = filtered_vm_total_;
-    row->filtered_filesize = filtered_file_total_;
+    row->size.vm = vm_total_;
+    row->size.file = file_total_;
+    row->filtered_size.vm = filtered_vm_total_;
+    row->filtered_size.file = filtered_file_total_;
     row->vmpercent = 100;
     row->filepercent = 100;
     output->diff_mode_ = true;
@@ -413,11 +413,41 @@ void Rollup::CreateRows(RollupRow* row, const Rollup* base,
   }
 
   for (const auto& value : children_) {
-    if (value.second->vm_total_ != 0 || value.second->file_total_ != 0) {
+    int64_t vm_total = value.second->vm_total_;
+    int64_t file_total = value.second->file_total_;
+    Rollup* base_child = nullptr;
+
+    if (base) {
+      // Reassign sizes to base during a diff to compare to target sizes.
+      auto it = base->children_.find(value.first);
+      if (it != base->children_.end()) {
+        base_child = it->second.get();
+        vm_total -= base_child->vm_total_;
+        file_total -= base_child->file_total_;
+      }
+    }
+
+    if (vm_total != 0 || file_total != 0) {
       row->sorted_children.emplace_back(value.first);
       RollupRow& child_row = row->sorted_children.back();
-      child_row.vmsize = value.second->vm_total_;
-      child_row.filesize = value.second->file_total_;
+      child_row.size.vm = vm_total;
+      child_row.size.file = file_total;
+
+      // Preserve the old and new sizes for this label in the RollupRow output.
+      // If there is a diff base, the old sizes come from the size of the label
+      // in that base.  Otherwise, the old size is the same as the new (current)
+      // size.
+      if (base_child) {
+        child_row.old_size.vm = base_child->vm_total_;
+        child_row.old_size.file = base_child->file_total_;
+        child_row.new_size.vm = value.second->vm_total_;
+        child_row.new_size.file = value.second->file_total_;
+      } else {
+        child_row.old_size.vm = child_row.size.vm;
+        child_row.old_size.file = child_row.size.file;
+        child_row.new_size.vm = child_row.size.vm;
+        child_row.new_size.file = child_row.size.file;
+      }
     }
   }
 
@@ -452,14 +482,14 @@ void Rollup::SortAndAggregateRows(RollupRow* row, const Rollup* base,
   for (auto& child : child_rows) {
     switch (options.sort_by()) {
       case Options::SORTBY_VMSIZE:
-        child.sortkey = std::abs(child.vmsize);
+        child.sortkey = std::abs(child.size.vm);
         break;
       case Options::SORTBY_FILESIZE:
-        child.sortkey = std::abs(child.filesize);
+        child.sortkey = std::abs(child.size.file);
         break;
       case Options::SORTBY_BOTH:
         child.sortkey =
-            std::max(std::abs(child.vmsize), std::abs(child.filesize));
+            std::max(std::abs(child.size.vm), std::abs(child.size.file));
         break;
       default:
         BLOATY_UNREACHABLE();
@@ -478,8 +508,8 @@ void Rollup::SortAndAggregateRows(RollupRow* row, const Rollup* base,
   // out to "others_row".
   size_t i = child_rows.size() - 1;
   while (i >= options.max_rows_per_level()) {
-    CheckedAdd(&others_row.vmsize, child_rows[i].vmsize);
-    CheckedAdd(&others_row.filesize, child_rows[i].filesize);
+    CheckedAdd(&others_row.size.vm, child_rows[i].size.vm);
+    CheckedAdd(&others_row.size.file, child_rows[i].size.file);
     if (base) {
       auto it = base->children_.find(child_rows[i].name);
       if (it != base->children_.end()) {
@@ -492,26 +522,26 @@ void Rollup::SortAndAggregateRows(RollupRow* row, const Rollup* base,
     i--;
   }
 
-  if (std::abs(others_row.vmsize) > 0 || std::abs(others_row.filesize) > 0) {
+  if (std::abs(others_row.size.vm) > 0 || std::abs(others_row.size.file) > 0) {
     child_rows.push_back(others_row);
-    CheckedAdd(&others_rollup.vm_total_, others_row.vmsize);
-    CheckedAdd(&others_rollup.file_total_, others_row.filesize);
+    CheckedAdd(&others_rollup.vm_total_, others_row.size.vm);
+    CheckedAdd(&others_rollup.file_total_, others_row.size.file);
   }
 
   // Now sort by actual value (positive or negative).
   for (auto& child : child_rows) {
     switch (options.sort_by()) {
       case Options::SORTBY_VMSIZE:
-        child.sortkey = child.vmsize;
+        child.sortkey = child.size.vm;
         break;
       case Options::SORTBY_FILESIZE:
-        child.sortkey = child.filesize;
+        child.sortkey = child.size.file;
         break;
       case Options::SORTBY_BOTH:
-        if (std::abs(child.vmsize) > std::abs(child.filesize)) {
-          child.sortkey = child.vmsize;
+        if (std::abs(child.size.vm) > std::abs(child.size.file)) {
+          child.sortkey = child.size.vm;
         } else {
-          child.sortkey = child.filesize;
+          child.sortkey = child.size.file;
         }
         break;
       default:
@@ -524,8 +554,8 @@ void Rollup::SortAndAggregateRows(RollupRow* row, const Rollup* base,
   // For a non-diff, the percentage is compared to the total size of the parent.
   if (!base) {
     for (auto& child_row : child_rows) {
-      child_row.vmpercent = Percent(child_row.vmsize, row->vmsize);
-      child_row.filepercent = Percent(child_row.filesize, row->filesize);
+      child_row.vmpercent = Percent(child_row.size.vm, row->size.vm);
+      child_row.filepercent = Percent(child_row.size.file, row->size.file);
     }
   }
 
@@ -698,8 +728,8 @@ void RollupOutput::PrettyPrintRow(const RollupRow& row, size_t indent,
   if (&row != &toplevel_row_) {
     // Avoid printing this row if it is only zero.
     // This can happen when using --domain if the row is zero for this domain.
-    if ((!ShowFile(options) && row.vmsize == 0) ||
-        (!ShowVM(options) && row.filesize == 0)) {
+    if ((!ShowFile(options) && row.size.vm == 0) ||
+        (!ShowVM(options) && row.size.file == 0)) {
       return;
     }
   }
@@ -708,12 +738,12 @@ void RollupOutput::PrettyPrintRow(const RollupRow& row, size_t indent,
 
   if (ShowFile(options)) {
     *out << PercentString(row.filepercent, diff_mode_) << " "
-         << SiPrint(row.filesize, diff_mode_) << " ";
+         << SiPrint(row.size.file, diff_mode_) << " ";
   }
 
   if (ShowVM(options)) {
     *out << PercentString(row.vmpercent, diff_mode_) << " "
-         << SiPrint(row.vmsize, diff_mode_) << " ";
+         << SiPrint(row.size.vm, diff_mode_) << " ";
   }
 
   *out << "   " << row.name << "\n";
@@ -737,7 +767,7 @@ void RollupOutput::PrettyPrintTree(const RollupRow& row, size_t indent,
   // Rows are printed before their sub-rows.
   PrettyPrintRow(row, indent, options, out);
 
-  if (!row.vmsize && !row.filesize) {
+  if (!row.size.vm && !row.size.file) {
     return;
   }
 
@@ -783,11 +813,12 @@ void RollupOutput::PrettyPrint(const OutputOptions& options,
 
   uint64_t file_filtered = 0;
   uint64_t vm_filtered = 0;
+  uint64_t filtered = 0;
   if (ShowFile(options)) {
-    file_filtered = toplevel_row_.filtered_filesize;
+    filtered += toplevel_row_.filtered_size.file;
   }
   if (ShowVM(options)) {
-    vm_filtered = toplevel_row_.filtered_vmsize;
+    filtered += toplevel_row_.filtered_size.vm;
   }
 
   if (vm_filtered == 0 && file_filtered == 0) {
@@ -816,8 +847,12 @@ void RollupOutput::PrintRowToCSV(const RollupRow& row,
     parent_labels.push_back("");
   }
 
-  parent_labels.push_back(std::to_string(row.vmsize));
-  parent_labels.push_back(std::to_string(row.filesize));
+  parent_labels.push_back(std::to_string(row.size.vm));
+  parent_labels.push_back(std::to_string(row.size.file));
+  parent_labels.push_back(std::to_string(row.old_size.vm));	
+  parent_labels.push_back(std::to_string(row.old_size.file));	
+  parent_labels.push_back(std::to_string(row.new_size.vm));	
+  parent_labels.push_back(std::to_string(row.new_size.file));
 
   std::string sep = tabs ? "\t" : ",";
   *out << absl::StrJoin(parent_labels, sep) << "\n";
@@ -845,6 +880,12 @@ void RollupOutput::PrintToCSV(std::ostream* out, bool tabs) const {
   std::vector<std::string> names(source_names_);
   names.push_back("vmsize");
   names.push_back("filesize");
+  names.push_back("vmcapacity");	
+  names.push_back("filecapacity");	
+  names.push_back("original_vmsize");	
+  names.push_back("original_filesize");	
+  names.push_back("current_vmsize");	
+  names.push_back("current_filesize");
   std::string sep = tabs ? "\t" : ",";
   *out << absl::StrJoin(names, sep) << "\n";
   for (const auto& child_row : toplevel_row_.sorted_children) {

--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -288,20 +288,6 @@ class Rollup {
     filter_regex_ = regex;
   }
 
-  // Subtract the values in "other" from this.
-  void Subtract(const Rollup& other) {
-    vm_total_ -= other.vm_total_;
-    file_total_ -= other.file_total_;
-
-    for (const auto& other_child : other.children_) {
-      auto& child = children_[other_child.first];
-      if (child.get() == NULL) {
-        child.reset(new Rollup());
-      }
-      child->Subtract(*other_child.second);
-    }
-  }
-
   // Add the values in "other" from this.
   void Add(const Rollup& other) {
     vm_total_ += other.vm_total_;

--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -337,18 +337,31 @@ void DisassembleFindReferences(const DisassemblyInfo& info, RangeSink* sink);
 
 class Rollup;
 
+struct DomainSizes {
+  int64_t vm;
+  int64_t file;
+};
+
 struct RollupRow {
   RollupRow(const std::string& name_) : name(name_) {}
 
   std::string name;
-  int64_t vmsize = 0;
-  int64_t filesize = 0;
-  int64_t filtered_vmsize = 0;
-  int64_t filtered_filesize = 0;
+  DomainSizes size = {0, 0};
+  DomainSizes filtered_size = {0, 0};
+
   int64_t other_count = 0;
   int64_t sortkey;
   double vmpercent;
   double filepercent;
+
+  // The size of this row in a diff base.  Same as `size` for non-diff.
+  DomainSizes old_size = {0, 0};
+  // The current size of this row (this is not the same as `size` in the case
+  // of a diff -- `size` is the delta).
+  DomainSizes new_size = {0, 0};
+
+  DomainSizes capacity = {0, 0};
+  
   std::vector<RollupRow> sorted_children;
 
   static bool Compare(const RollupRow& a, const RollupRow& b) {

--- a/tests/bloaty_misc_test.cc
+++ b/tests/bloaty_misc_test.cc
@@ -27,7 +27,7 @@ TEST_F(BloatyTest, InlinesOnSmallFile) {
       {"bloaty", "-d", "compileunits", "03-small-binary-that-crashed-inlines.bin"});
   RunBloaty(
       {"bloaty", "-d", "inlines", "03-small-binary-that-crashed-inlines.bin"});
-  EXPECT_EQ(top_row_->vmsize, 2340);
+  EXPECT_EQ(top_row_->size.vm, 2340);
 }
 
 TEST_F(BloatyTest, GoBinary) {
@@ -46,7 +46,7 @@ TEST_F(BloatyTest, ImplicitConstAndLineStrp) {
 
 TEST_F(BloatyTest, MultiThreaded) {
   RunBloaty({"bloaty", "02-section-count-overflow.o"});
-  size_t file_size = top_row_->filesize;
+  size_t file_size = top_row_->size.file;
 
   // Bloaty doesn't know or care that you are passing the same file multiple
   // times.
@@ -56,5 +56,5 @@ TEST_F(BloatyTest, MultiThreaded) {
     args.push_back("02-section-count-overflow.o");
   }
   RunBloaty(args);  // Heavily multithreaded test.
-  EXPECT_EQ(top_row_->filesize, file_size * 100);
+  EXPECT_EQ(top_row_->size.file, file_size * 100);
 }

--- a/tests/bloaty_test.cc
+++ b/tests/bloaty_test.cc
@@ -21,20 +21,20 @@ TEST_F(BloatyTest, EmptyObjectFile) {
 
   // Empty .c file should result in a .o file with no vmsize.
   RunBloaty({"bloaty", file});
-  EXPECT_EQ(top_row_->vmsize, 0);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_EQ(top_row_->size.vm, 0);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 1);
 
   // Same with segments (we fake segments on .o files).
   RunBloaty({"bloaty", "-d", "segments", file});
-  EXPECT_EQ(top_row_->vmsize, 0);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_EQ(top_row_->size.vm, 0);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 1);
 
   // Same with symbols.
   RunBloaty({"bloaty", "-d", "symbols", file});
-  EXPECT_EQ(top_row_->vmsize, 0);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_EQ(top_row_->size.vm, 0);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 1);
 
   // We can't run any of these targets against object files.
@@ -50,16 +50,16 @@ TEST_F(BloatyTest, SimpleObjectFile) {
 
   // Test "-n 0" which should return an unlimited number of rows.
   RunBloaty({"bloaty", "-n", "0", file});
-  EXPECT_GT(top_row_->vmsize, 64);
-  EXPECT_LT(top_row_->vmsize, 300);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 64);
+  EXPECT_LT(top_row_->size.vm, 300);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 1);
 
   // Same with segments (we fake segments on .o files).
   RunBloaty({"bloaty", "-d", "segments", file});
-  EXPECT_GT(top_row_->vmsize, 64);
-  EXPECT_LT(top_row_->vmsize, 300);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 64);
+  EXPECT_LT(top_row_->size.vm, 300);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 1);
 
   // For inputfiles we should get everything attributed to the input file.
@@ -111,15 +111,15 @@ TEST_F(BloatyTest, SimpleArchiveFile) {
   ASSERT_TRUE(GetFileSize(file, &size));
 
   RunBloaty({"bloaty", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  //EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  //EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 3);
 
   RunBloaty({"bloaty", "-d", "segments", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  //EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  //EXPECT_EQ(top_row_->size.file, size);
 
   RunBloaty({"bloaty", "-d", "symbols", "-n", "40", "-s", "vm", file});
   AssertChildren(*top_row_, {
@@ -174,15 +174,15 @@ TEST_F(BloatyTest, SimpleSharedObjectFile) {
   ASSERT_TRUE(GetFileSize(file, &size));
 
   RunBloaty({"bloaty", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 3);
 
   RunBloaty({"bloaty", "-d", "segments", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  EXPECT_EQ(top_row_->size.file, size);
 
   RunBloaty({"bloaty", "-d", "symbols", "-n", "50", file});
   AssertChildren(*top_row_, {
@@ -199,15 +199,15 @@ TEST_F(BloatyTest, SimpleBinary) {
   ASSERT_TRUE(GetFileSize(file, &size));
 
   RunBloaty({"bloaty", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 3);
 
   RunBloaty({"bloaty", "-d", "segments", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  EXPECT_EQ(top_row_->size.file, size);
 
   RunBloaty({"bloaty", "-d", "symbols", "-n", "50", "-s", "vm", file});
   AssertChildren(*top_row_, {

--- a/tests/test.h
+++ b/tests/test.h
@@ -81,16 +81,16 @@ class BloatyTest : public ::testing::Test {
       uint64_t vmtotal = 0;
       uint64_t filetotal = 0;
       for (const auto& child : row.sorted_children) {
-        vmtotal += child.vmsize;
-        filetotal += child.filesize;
+        vmtotal += child.size.vm;
+        filetotal += child.size.file;
         CheckConsistencyForRow(child, false, diff_mode, count);
         ASSERT_TRUE(names.insert(child.name).second);
-        ASSERT_FALSE(child.vmsize == 0 && child.filesize == 0);
+        ASSERT_FALSE(child.size.vm == 0 && child.size.file == 0);
       }
 
       if (!diff_mode) {
-        ASSERT_EQ(vmtotal, row.vmsize);
-        ASSERT_EQ(filetotal, row.filesize);
+        ASSERT_EQ(vmtotal, row.size.vm);
+        ASSERT_EQ(filetotal, row.size.file);
       }
     } else {
       // Count leaf rows.
@@ -147,7 +147,7 @@ class BloatyTest : public ::testing::Test {
         ASSERT_TRUE(GetFileSize(filename, &size));
         total_input_size += size;
       }
-      ASSERT_EQ(top_row_->filesize, total_input_size);
+      ASSERT_EQ(top_row_->size.file, total_input_size);
     }
 
     int rows = 0;
@@ -248,21 +248,21 @@ class BloatyTest : public ::testing::Test {
       if (expected_vm == kUnknown) {
         // Always pass.
       } else if (expected_vm > 0) {
-        EXPECT_GE(child.vmsize, expected_vm);
+        EXPECT_GE(child.size.vm, expected_vm);
         // Allow some overhead.
-        EXPECT_LE(child.vmsize, (expected_vm * 1.1) + 100);
+        EXPECT_LE(child.size.vm, (expected_vm * 1.1) + 100);
       } else {
         ASSERT_TRUE(false);
       }
 
       if (expected_file == kSameAsVM) {
-        expected_file = child.vmsize;
+        expected_file = child.size.vm;
       }
 
       if (expected_file != kUnknown) {
-        EXPECT_GE(child.filesize, expected_file);
+        EXPECT_GE(child.size.file, expected_file);
         // Allow some overhead.
-        EXPECT_LE(child.filesize, (expected_file * 1.2) + 180);
+        EXPECT_LE(child.size.file, (expected_file * 1.2) + 180);
       }
 
       if (++i == children.size()) {


### PR DESCRIPTION
Implement Label Capacity feature to allow users to visualize their size reports with specified capacities for labels as a percentage. Additionally, save the sizes of the target and base binaries when running in Diff mode to understand the context of the deltas more clearly.